### PR TITLE
Exclude query string from path_info

### DIFF
--- a/etc/nginx/lucee-proxy.conf
+++ b/etc/nginx/lucee-proxy.conf
@@ -19,7 +19,7 @@ proxy_set_header X-Webserver-Context $lucee_context;
 # Enable path_info - http://www.lucee.nl/post.cfm/enable-path-info-on-nginx-with-lucee-and-railo
 set $pathinfo "";
 # if the extension .cfm or .cfc is found, followed by a slash and optional extra
-if ($uri ~ "^(.+?\.cf[mc])(/.*)") {
+if ($uri ~ "^(.+?\.cf[mc])(/.*)(\?.*)") {
     # remember the filepath without path_info
     set $script $1;
     set $pathinfo $2;


### PR DESCRIPTION
The current regex to populate the path_info header includes the query string if one exists.

path_info should not include the query string and this tweak to the regex excludes it.